### PR TITLE
Add minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.11)
 project(sfml-starter)
 
 include(FetchContent)


### PR DESCRIPTION
CMake gets upset that a minimum version has not been specified.

FetchContent was also introduced in CMake version 3.11, so I've added a default minimum to cmake version 3.11.

This is a pretty trivial change and should not really affect much.