### PR TITLE
Address issues discussed a few weeks back with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.11)
 project(sfml-starter)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(FetchContent)
 
+set(BUILD_SHARED_LIBS OFF)
 FetchContent_Declare(sfml
   GIT_REPOSITORY https://github.com/SFML/SFML
   GIT_TAG 2f11710abc5aa478503a7ff3f9e654bd2078ebab


### PR DESCRIPTION
This covers the issues windows was having with CMake we discussed a few weeks back. The project is still locked to C++17 due to the past issues we discussed, but C++17 is a pretty decent minimum anyways. Still I still think I'd be worth further investigating this issue as a robust template should provide as many options as possible to the user with as little upfront configuration as possible. For now this is a bandaid to make SFML work for windows users without needing to figure it out on there own.